### PR TITLE
Update path from machadovilaca to rhobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ goclean:
 
 goimport:
 	go install golang.org/x/tools/cmd/goimports@latest
-	goimports -w -local="github.com/machadovilaca/operator-observability"  $(shell find . -type f -name '*.go' ! -path "*/vendor/*" )
+	goimports -w -local="github.com/rhobs/operator-observability"  $(shell find . -type f -name '*.go' ! -path "*/vendor/*" )
 
 test:
 	go test -v ./pkg/...

--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ Empower Kubernetes Operator developers with tools that align with the
 Explore the [examples](_examples) directory for hands-on guidance on leveraging
 these utilities and wrappers.
 
-Or check the step-by-step tutorial on how to use this package to instrument a
-simple operator-sdk operator:
-https://github.com/machadovilaca/operator-observability-tutorial.
-
 ## Design
 
 ### Metrics

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -1,9 +1,9 @@
-module github.com/machadovilaca/operator-observability/examples
+module github.com/rhobs/operator-observability/examples
 
 go 1.21
 
 require (
-	github.com/machadovilaca/operator-observability v0.0.0-00010101000000-000000000000
+	github.com/rhobs/operator-observability v0.0.0-00010101000000-000000000000
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.68.0
 	github.com/prometheus/client_golang v1.16.0
 	k8s.io/apimachinery v0.28.1
@@ -59,4 +59,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/machadovilaca/operator-observability => ../
+replace github.com/rhobs/operator-observability => ../

--- a/_examples/main.go
+++ b/_examples/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/machadovilaca/operator-observability/examples/metrics"
+	"github.com/rhobs/operator-observability/examples/metrics"
 )
 
 func main() {

--- a/_examples/metrics/custom_resource_collector.go
+++ b/_examples/metrics/custom_resource_collector.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
 )
 
 var (

--- a/_examples/metrics/metrics.go
+++ b/_examples/metrics/metrics.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
 )
 
 const metricPrefix = "guestbook_operator_"

--- a/_examples/metrics/operator_metrics.go
+++ b/_examples/metrics/operator_metrics.go
@@ -1,6 +1,6 @@
 package metrics
 
-import "github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+import "github.com/rhobs/operator-observability/pkg/operatormetrics"
 
 var (
 	operatorMetrics = []operatormetrics.Metric{

--- a/_examples/metrics/per_second_data_collector.go
+++ b/_examples/metrics/per_second_data_collector.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
 )
 
 var (

--- a/_examples/rules/operator_recording_rules.go
+++ b/_examples/rules/operator_recording_rules.go
@@ -5,8 +5,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
 )
 
 var operatorRecordingRules = []operatorrules.RecordingRule{

--- a/_examples/rules/rules.go
+++ b/_examples/rules/rules.go
@@ -3,7 +3,7 @@ package rules
 import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
 )
 
 const (

--- a/_examples/tools/docs/alerts.go
+++ b/_examples/tools/docs/alerts.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/machadovilaca/operator-observability/examples/rules"
-	"github.com/machadovilaca/operator-observability/pkg/docs"
+	"github.com/rhobs/operator-observability/examples/rules"
+	"github.com/rhobs/operator-observability/pkg/docs"
 )
 
 func main() {

--- a/_examples/tools/docs/metrics.go
+++ b/_examples/tools/docs/metrics.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/machadovilaca/operator-observability/examples/metrics"
-	"github.com/machadovilaca/operator-observability/examples/rules"
-	"github.com/machadovilaca/operator-observability/pkg/docs"
+	"github.com/rhobs/operator-observability/examples/metrics"
+	"github.com/rhobs/operator-observability/examples/rules"
+	"github.com/rhobs/operator-observability/pkg/docs"
 )
 
 const tpl = `# Guestbook Operator Metrics

--- a/_examples/tools/lint/lint.go
+++ b/_examples/tools/lint/lint.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/machadovilaca/operator-observability/examples/rules"
-	"github.com/machadovilaca/operator-observability/pkg/testutil"
+	"github.com/rhobs/operator-observability/examples/rules"
+	"github.com/rhobs/operator-observability/pkg/testutil"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/machadovilaca/operator-observability
+module github.com/rhobs/operator-observability
 
 go 1.21
 

--- a/pkg/declarative/configuration.go
+++ b/pkg/declarative/configuration.go
@@ -4,8 +4,8 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
 )
 
 type Config struct {

--- a/pkg/docs/metrics.go
+++ b/pkg/docs/metrics.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
 )
 
 const defaultMetricsTemplate = `# Operator Metrics

--- a/pkg/docs/metrics_test.go
+++ b/pkg/docs/metrics_test.go
@@ -8,9 +8,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/machadovilaca/operator-observability/pkg/docs"
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/docs"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
 )
 
 const tpl = `#metrics-doc-test-title

--- a/pkg/operatormetrics/collector_result_test.go
+++ b/pkg/operatormetrics/collector_result_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
 )
 
 var _ = Describe("CollectorResult", func() {

--- a/pkg/operatormetrics/collector_test.go
+++ b/pkg/operatormetrics/collector_test.go
@@ -10,7 +10,7 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
 )
 
 var _ = Describe("Collector", func() {

--- a/pkg/operatormetrics/metric_test.go
+++ b/pkg/operatormetrics/metric_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
 )
 
 var _ = Describe("Metrics", func() {

--- a/pkg/operatormetrics/wrapper_registry_test.go
+++ b/pkg/operatormetrics/wrapper_registry_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
 )
 
 var _ = Describe("Registry", func() {

--- a/pkg/operatorrules/compatibility_test.go
+++ b/pkg/operatorrules/compatibility_test.go
@@ -8,8 +8,8 @@ import (
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
 )
 
 var _ = Describe("OperatorRules", func() {

--- a/pkg/operatorrules/prometheusrules_test.go
+++ b/pkg/operatorrules/prometheusrules_test.go
@@ -8,8 +8,8 @@ import (
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
 )
 
 var _ = Describe("PrometheusRules", func() {

--- a/pkg/operatorrules/recordingrule.go
+++ b/pkg/operatorrules/recordingrule.go
@@ -3,7 +3,7 @@ package operatorrules
 import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
 )
 
 // RecordingRule is a struct that represents a Prometheus recording rule.

--- a/pkg/operatorrules/registry_test.go
+++ b/pkg/operatorrules/registry_test.go
@@ -8,8 +8,8 @@ import (
 
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
 )
 
 var _ = Describe("OperatorRules", func() {

--- a/pkg/testutil/alert_custom_validation_test.go
+++ b/pkg/testutil/alert_custom_validation_test.go
@@ -7,7 +7,7 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/machadovilaca/operator-observability/pkg/testutil"
+	"github.com/rhobs/operator-observability/pkg/testutil"
 )
 
 var _ = Describe("Custom Validators", func() {

--- a/pkg/testutil/alert_validation_test.go
+++ b/pkg/testutil/alert_validation_test.go
@@ -7,7 +7,7 @@ import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/machadovilaca/operator-observability/pkg/testutil"
+	"github.com/rhobs/operator-observability/pkg/testutil"
 )
 
 var _ = Describe("Default Validators", func() {

--- a/pkg/testutil/fetch_metrics_test.go
+++ b/pkg/testutil/fetch_metrics_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 
-	"github.com/machadovilaca/operator-observability/pkg/testutil"
+	"github.com/rhobs/operator-observability/pkg/testutil"
 )
 
 //go:embed testdata/metrics.txt

--- a/pkg/testutil/linter.go
+++ b/pkg/testutil/linter.go
@@ -3,7 +3,7 @@ package testutil
 import (
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
 )
 
 type Linter struct {

--- a/pkg/testutil/recording_rule_validation.go
+++ b/pkg/testutil/recording_rule_validation.go
@@ -1,7 +1,7 @@
 package testutil
 
 import (
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
 )
 
 type RecordRuleValidation = func(rr *operatorrules.RecordingRule) []Problem

--- a/pkg/testutil/recording_rule_validation_test.go
+++ b/pkg/testutil/recording_rule_validation_test.go
@@ -6,9 +6,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/machadovilaca/operator-observability/pkg/operatormetrics"
-	"github.com/machadovilaca/operator-observability/pkg/operatorrules"
-	"github.com/machadovilaca/operator-observability/pkg/testutil"
+	"github.com/rhobs/operator-observability/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability/pkg/operatorrules"
+	"github.com/rhobs/operator-observability/pkg/testutil"
 )
 
 var _ = Describe("Validators", func() {


### PR DESCRIPTION
Update all places that included the
github.com/machadovilaca/operator-observability path with github.com/rhobs/operator-observability.

Signed-off-by: Shirly Radco <sradco@redhat.com>